### PR TITLE
RX Game balance for std/ctb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "titanic-pp"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["MaxOhn <ohn.m@hotmail.de>", "tsunyoku <tsunyoku@gmail.com>", "Lekuruu <contact@lekuru.xyz>", "kanaarima <akataltosu@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/catch/pp.rs
+++ b/src/catch/pp.rs
@@ -403,6 +403,11 @@ impl CatchPPInner {
             pp *= 0.9;
         }
 
+        // RX penalty
+        if self.mods.rx() {
+            pp *= 0.25;
+        }
+
         CatchPerformanceAttributes {
             difficulty: self.attributes,
             pp,

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -281,7 +281,7 @@ impl<'m> OsuPP<'m> {
             false => 1.0,
         };
 
-        let mut pp = (aim_value.powf(1.185 * nodt_bonus)
+        let mut pp = (aim_value.powf(1.15 * nodt_bonus)
             + speed_value.powf(0.83 * acc_depression * 0.1)
             + acc_value.powf(1.14 * nodt_bonus))
         .powf(1.0 / 1.1)

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -383,7 +383,7 @@ impl<'m> OsuPP<'m> {
             (5.0 * (attributes.speed_strain as f32 / 0.0675).max(1.0) - 4.0).powi(3) / 100_000.0;
 
         // Longer maps are worth more
-        let len_bonus = 0.88
+        let len_bonus = 1.0
             + 0.4 * (total_hits / 2000.0).min(1.0)
             + (total_hits > 2000.0) as u8 as f32 * 0.5 * (total_hits / 2000.0).log10();
         speed_value *= len_bonus;

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -277,7 +277,7 @@ impl<'m> OsuPP<'m> {
         }
 
         let nodt_bonus = match !self.mods.change_speed() {
-            true => 1.02,
+            true => 0.98,
             false => 1.0,
         };
 

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -282,13 +282,17 @@ impl<'m> OsuPP<'m> {
         };
 
         let mut pp = (aim_value.powf(1.185 * nodt_bonus)
-            + speed_value.powf(0.83 * acc_depression)
+            + speed_value.powf(0.83 * acc_depression * 0.1)
             + acc_value.powf(1.14 * nodt_bonus))
         .powf(1.0 / 1.1)
             * multiplier;
 
         if self.mods.dt() && self.mods.hr() {
             pp *= 1.025;
+        }
+
+        if speed_value > aim_value {
+            pp *= aim_value / speed_value;
         }
 
         OsuPerformanceAttributes {
@@ -368,7 +372,7 @@ impl<'m> OsuPP<'m> {
         // Scale with accuracy
         aim_value *= 0.3 + self.acc.unwrap() / 2.0;
         aim_value *= 0.98 + attributes.od as f32 * attributes.od as f32 / 2500.0;
-
+        
         aim_value
     }
 

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -291,46 +291,6 @@ impl<'m> OsuPP<'m> {
             pp *= 1.025;
         }
 
-        if self.map.creator == "gwb" || self.map.creator == "Plasma" {
-            pp *= 0.9;
-        }
-
-        pp *= match self.map.beatmap_id {
-            // Louder than steel [ok this is epic]
-            1808605 => 0.85,
-
-            // over the top [Above the stars]
-            1821147 => 0.70,
-
-            // Just press F [Parkour's ok this is epic]
-            1844776 => 0.64,
-
-            // Hardware Store [skyapple mode]
-            1777768 => 0.90,
-
-            // Akatsuki compilation [ok this is akatsuki]
-            1962833 => {
-                pp *= 0.885;
-
-                if self.mods.dt() {
-                    0.83
-                } else {
-                    1.0
-                }
-            }
-
-            // Songs Compilation [Marathon]
-            2403677 => 0.85,
-
-            // Songs Compilation [Remembrance]
-            2174272 => 0.85,
-
-            // Apocalypse 1992 [Universal Annihilation]
-            2382377 => 0.85,
-
-            _ => 1.0,
-        };
-
         OsuPerformanceAttributes {
             difficulty: self.attributes.unwrap(),
             pp_acc: 0.0,


### PR DESCRIPTION
PR aims to address RX/VN inbalance by

1. Nerfing CTB RX with a 0.25x multiplier (nerfing properly is too difficult)
2. Nerfing NM/HR maps 
3. Slightly nerfing aim
4. Speed nerf (length bonus, plain speed nerf)

Other changes:

1. Dump version to 0.0.2
2. Remove unused beatmap specific nerfes