### PR TITLE
Taiko rx + (minor) standard rx rework

### DIFF
--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -672,7 +672,14 @@ impl OsuPpInner {
         if self.attrs.max_combo == 0 {
             1.0
         } else {
-            ((self.state.max_combo as f64).powf(0.8) / (self.attrs.max_combo as f64).powf(0.8))
+            // 1 miss every 350 objects
+            let tolerable_misses = ((self.attrs.n_circles + self.attrs.n_sliders + self.attrs.n_spinners) as f64) / 350.0;
+            let mut actual_combo = self.state.max_combo as f64;
+            // Boost combo by 1.5x if misses are under tolerable misses threshold
+            if (self.state.n_misses as f64) < tolerable_misses {
+                actual_combo = (actual_combo*(1.5)).min(self.attrs.max_combo as f64);
+            }
+            (actual_combo.powf(0.8) / (self.attrs.max_combo as f64).powf(0.8))
                 .min(1.0)
         }
     }

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -278,7 +278,7 @@ impl<'m> OsuPP<'m> {
 
         let nodt_bonus = match !self.mods.change_speed() {
             true => 0.975,
-            false => 0.99,
+            false => 0.97,
         };
 
         let mut pp = (aim_value.powf(1.125 * nodt_bonus)
@@ -292,7 +292,7 @@ impl<'m> OsuPP<'m> {
         }
 
         if speed_value > aim_value {
-            pp *= (aim_value / speed_value) * 1.05;
+            pp *= (aim_value / speed_value) * 1.1;
         }
 
         OsuPerformanceAttributes {

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -281,7 +281,7 @@ impl<'m> OsuPP<'m> {
             false => 1.0,
         };
 
-        let mut pp = (aim_value.powf(1.15 * nodt_bonus)
+        let mut pp = (aim_value.powf(1.145 * nodt_bonus)
             + speed_value.powf(0.83 * acc_depression * 0.1)
             + acc_value.powf(1.14 * nodt_bonus))
         .powf(1.0 / 1.1)
@@ -292,7 +292,7 @@ impl<'m> OsuPP<'m> {
         }
 
         if speed_value > aim_value {
-            pp *= aim_value / speed_value;
+            pp *= (aim_value / speed_value) * 1.05;
         }
 
         OsuPerformanceAttributes {
@@ -342,7 +342,7 @@ impl<'m> OsuPP<'m> {
         }
 
         aim_value *= 1.0 + ar_factor as f32 * len_bonus;
-
+        
         // HD bonus
         if self.mods.hd() {
             aim_value *= 1.0 + 0.05 * (11.0 - attributes.ar) as f32;

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -278,10 +278,10 @@ impl<'m> OsuPP<'m> {
 
         let nodt_bonus = match !self.mods.change_speed() {
             true => 0.975,
-            false => 0.995,
+            false => 0.99,
         };
 
-        let mut pp = (aim_value.powf(1.145 * nodt_bonus)
+        let mut pp = (aim_value.powf(1.125 * nodt_bonus)
             + speed_value.powf(0.83 * acc_depression * 0.1)
             + acc_value.powf(1.14 * nodt_bonus))
         .powf(1.0 / 1.1)

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -277,8 +277,8 @@ impl<'m> OsuPP<'m> {
         }
 
         let nodt_bonus = match !self.mods.change_speed() {
-            true => 0.98,
-            false => 1.0,
+            true => 0.975,
+            false => 0.995,
         };
 
         let mut pp = (aim_value.powf(1.145 * nodt_bonus)

--- a/src/taiko/pp.rs
+++ b/src/taiko/pp.rs
@@ -300,7 +300,14 @@ impl TaikoPpInner {
         let diff_value = self.compute_difficulty_value(effective_miss_count);
         let acc_value = self.compute_accuracy_value();
 
-        let pp = (diff_value.powf(1.1) + acc_value.powf(1.1)).powf(1.0 / 1.1) * multiplier;
+        let mut pp = (diff_value.powf(1.1) + acc_value.powf(1.1)).powf(1.0 / 1.1) * multiplier;
+        
+        if self.mods.rx() {
+            let color_nerf = self.attrs.colour / (self.attrs.rhythm * 2.0);
+            if color_nerf > 1.0 {
+                pp /= color_nerf;
+            }
+        }
 
         TaikoPerformanceAttributes {
             difficulty: self.attrs,


### PR DESCRIPTION
Taiko rx:
1. Nerf color based on rhythm complexity

Standard rx:
1. Nerf DT+NM nodt_bonus multiplier
3. Nerf aim
4. Slightly buff speed for pure speed maps (eg time freeze)