### PR TITLE
Standard VN+RX rework

### DIFF
--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -672,10 +672,10 @@ impl OsuPpInner {
         if self.attrs.max_combo == 0 {
             1.0
         } else {
-            // 1 miss every 350 objects
-            let tolerable_misses = ((self.attrs.n_circles + self.attrs.n_sliders + self.attrs.n_spinners) as f64) / 385.0;
+            // 1 miss every 420 objects
+            let tolerable_misses = ((self.attrs.n_circles + self.attrs.n_sliders + self.attrs.n_spinners) as f64) / 420.0;
             let mut actual_combo = self.state.max_combo as f64;
-            let combo_boost = 1.54;
+            let combo_boost = 1.55;
             //let miss_factor = 1.0 - (1.0 * (self.state.n_misses as f64) / tolerable_misses);
             let miss_factor = 1.0;
             // Boost combo by 1.5x if misses are under tolerable misses threshold

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -675,7 +675,7 @@ impl OsuPpInner {
             // 1 miss every 350 objects
             let tolerable_misses = ((self.attrs.n_circles + self.attrs.n_sliders + self.attrs.n_spinners) as f64) / 385.0;
             let mut actual_combo = self.state.max_combo as f64;
-            let combo_boost = 1.52;
+            let combo_boost = 1.54;
             //let miss_factor = 1.0 - (1.0 * (self.state.n_misses as f64) / tolerable_misses);
             let miss_factor = 1.0;
             // Boost combo by 1.5x if misses are under tolerable misses threshold

--- a/src/osu/pp.rs
+++ b/src/osu/pp.rs
@@ -673,11 +673,14 @@ impl OsuPpInner {
             1.0
         } else {
             // 1 miss every 350 objects
-            let tolerable_misses = ((self.attrs.n_circles + self.attrs.n_sliders + self.attrs.n_spinners) as f64) / 350.0;
+            let tolerable_misses = ((self.attrs.n_circles + self.attrs.n_sliders + self.attrs.n_spinners) as f64) / 385.0;
             let mut actual_combo = self.state.max_combo as f64;
+            let combo_boost = 1.52;
+            //let miss_factor = 1.0 - (1.0 * (self.state.n_misses as f64) / tolerable_misses);
+            let miss_factor = 1.0;
             // Boost combo by 1.5x if misses are under tolerable misses threshold
             if (self.state.n_misses as f64) < tolerable_misses {
-                actual_combo = (actual_combo*(1.5)).min(self.attrs.max_combo as f64);
+                actual_combo = (actual_combo*(combo_boost*miss_factor)).min(self.attrs.max_combo as f64);
             }
             (actual_combo.powf(0.8) / (self.attrs.max_combo as f64).powf(0.8))
                 .min(1.0)

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -355,6 +355,18 @@ impl<'m> OsuPP<'m> {
             // Apocalypse 1992 [Universal Annihilation]
             2382377 => 0.85,
 
+            // Ascension to heaven
+            111680 => 0.82,
+
+            // senketsu no chikai
+            142954 => {
+                if self.mods.dt() && self.mods.hr() {
+                    0.9
+                } else {
+                    0.95
+                }
+            },
+            
             _ => 1.0,
         };
 

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -277,12 +277,12 @@ impl<'m> OsuPP<'m> {
         }
 
         let nodt_bonus = match !self.mods.change_speed() {
-            true => 0.975,
-            false => 0.97,
+            true => 1.02,
+            false => 1.0,
         };
 
-        let mut pp = (aim_value.powf(1.125 * nodt_bonus)
-            + speed_value.powf(0.83 * acc_depression * 0.1)
+        let mut pp = (aim_value.powf(1.185 * nodt_bonus)
+            + speed_value.powf(0.83 * acc_depression)
             + acc_value.powf(1.14 * nodt_bonus))
         .powf(1.0 / 1.1)
             * multiplier;
@@ -291,9 +291,45 @@ impl<'m> OsuPP<'m> {
             pp *= 1.025;
         }
 
-        if speed_value > aim_value {
-            pp *= (aim_value / speed_value) * 1.1;
+        if self.map.creator == "gwb" || self.map.creator == "Plasma" {
+            pp *= 0.9;
         }
+
+        pp *= match self.map.beatmap_id {
+            // Louder than steel [ok this is epic]
+            1808605 => 0.85,
+
+            // over the top [Above the stars]
+            1821147 => 0.70,
+
+            // Just press F [Parkour's ok this is epic]
+            1844776 => 0.64,
+
+            // Hardware Store [skyapple mode]
+            1777768 => 0.90,
+
+            // Akatsuki compilation [ok this is akatsuki]
+            1962833 => {
+                pp *= 0.885;
+
+                if self.mods.dt() {
+                    0.83
+                } else {
+                    1.0
+                }
+            }
+
+            // Songs Compilation [Marathon]
+            2403677 => 0.85,
+
+            // Songs Compilation [Remembrance]
+            2174272 => 0.85,
+
+            // Apocalypse 1992 [Universal Annihilation]
+            2382377 => 0.85,
+
+            _ => 1.0,
+        };
 
         OsuPerformanceAttributes {
             difficulty: self.attributes.unwrap(),
@@ -342,7 +378,7 @@ impl<'m> OsuPP<'m> {
         }
 
         aim_value *= 1.0 + ar_factor as f32 * len_bonus;
-        
+
         // HD bonus
         if self.mods.hd() {
             aim_value *= 1.0 + 0.05 * (11.0 - attributes.ar) as f32;
@@ -372,7 +408,7 @@ impl<'m> OsuPP<'m> {
         // Scale with accuracy
         aim_value *= 0.3 + self.acc.unwrap() / 2.0;
         aim_value *= 0.98 + attributes.od as f32 * attributes.od as f32 / 2500.0;
-        
+
         aim_value
     }
 
@@ -383,7 +419,7 @@ impl<'m> OsuPP<'m> {
             (5.0 * (attributes.speed_strain as f32 / 0.0675).max(1.0) - 4.0).powi(3) / 100_000.0;
 
         // Longer maps are worth more
-        let len_bonus = 1.0
+        let len_bonus = 0.88
             + 0.4 * (total_hits / 2000.0).min(1.0)
             + (total_hits > 2000.0) as u8 as f32 * 0.5 * (total_hits / 2000.0).log10();
         speed_value *= len_bonus;

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -360,18 +360,6 @@ impl<'m> OsuPP<'m> {
             // Apocalypse 1992 [Universal Annihilation]
             2382377 => 0.85,
 
-            // Ascension to heaven
-            111680 => 0.82,
-
-            // senketsu no chikai
-            142954 => {
-                if self.mods.dt() && self.mods.hr() {
-                    0.9
-                } else {
-                    0.95
-                }
-            },
-            
             _ => 1.0,
         };
 
@@ -399,7 +387,7 @@ impl<'m> OsuPP<'m> {
         let mut aim_value = (5.0 * (raw_aim / 0.0675).max(1.0) - 4.0).powi(3) / 100_000.0;
 
         // Longer maps are worth more
-        let len_bonus = 0.88
+        let len_bonus = 0.65
             + 0.4 * (total_hits / 2000.0).min(1.0)
             + (total_hits > 2000.0) as u8 as f32 * 0.5 * (total_hits / 2000.0).log10();
         aim_value *= len_bonus;
@@ -463,7 +451,7 @@ impl<'m> OsuPP<'m> {
             (5.0 * (attributes.speed_strain as f32 / 0.0675).max(1.0) - 4.0).powi(3) / 100_000.0;
 
         // Longer maps are worth more
-        let len_bonus = 0.88
+        let len_bonus = 0.8
             + 0.4 * (total_hits / 2000.0).min(1.0)
             + (total_hits > 2000.0) as u8 as f32 * 0.5 * (total_hits / 2000.0).log10();
         speed_value *= len_bonus;

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -278,8 +278,8 @@ impl<'m> OsuPP<'m> {
 
         let attributes = self.attributes.as_ref().unwrap();
 
-        let mut base_aim_nerf = 0.35;
-        let mut base_speed_nerf = 0.3;
+        let mut base_aim_nerf = 0.28;
+        let mut base_speed_nerf = 0.2;
 
         // Flow aim nerf
         let speed_aim_factor = speed_value/aim_value;
@@ -291,8 +291,8 @@ impl<'m> OsuPP<'m> {
 
         if attributes.ar >= 10.3 {
             let ar_boost = attributes.ar/11.0;
-            base_aim_nerf += (0.13 * ar_boost) as f32;
-            base_speed_nerf += (0.35 * ar_boost) as f32;
+            base_aim_nerf += (0.18 * ar_boost) as f32;
+            base_speed_nerf += (0.45 * ar_boost) as f32;
             // Precision buff
             if attributes.cs > 5.6 {
                 base_aim_nerf *= ((attributes.cs.max(7.0)/4.85) * ar_boost) as f32;

--- a/src/osu_2019/pp.rs
+++ b/src/osu_2019/pp.rs
@@ -292,7 +292,12 @@ impl<'m> OsuPP<'m> {
         if attributes.ar >= 10.3 {
             let ar_boost = attributes.ar/11.0;
             base_aim_nerf += (0.18 * ar_boost) as f32;
-            base_speed_nerf += (0.45 * ar_boost) as f32;
+            let speed_nerf_factor = if speed_value>aim_value {
+                0.225
+            } else {
+                0.45
+            };
+            base_speed_nerf += (speed_nerf_factor * ar_boost) as f32;
             // Precision buff
             if attributes.cs > 5.6 {
                 base_aim_nerf *= ((attributes.cs.max(7.0)/4.85) * ar_boost) as f32;

--- a/src/osu_2019/stars.rs
+++ b/src/osu_2019/stars.rs
@@ -28,6 +28,7 @@ pub fn stars(map: &Beatmap, mods: u32, passed_objects: Option<usize>) -> OsuDiff
     let mut diff_attributes = OsuDifficultyAttributes {
         ar: map_attributes.ar,
         od: map_attributes.od,
+        cs: map_attributes.cs,
         ..Default::default()
     };
 
@@ -148,6 +149,7 @@ pub struct OsuDifficultyAttributes {
     pub ar: f64,
     pub od: f64,
     pub hp: f64,
+    pub cs: f64,
     pub n_circles: usize,
     pub n_sliders: usize,
     pub n_spinners: usize,


### PR DESCRIPTION
Changes for standard:

- Buff combo scaling removal for longer maps
- Nerf combo scaling removal for short maps 

Changes for standard relax:

- Completely rewrite nerf system
- Nerf pure aim maps
- Balance aim/speed
- Buff CS 5.7+ on AR 10.3+
- Don't completely kill consistency maps
- ~~Manually nerf Senketsu no chikai~~ Not needed anymore
- Nerf length bonus